### PR TITLE
Fix gnupg upstream patch link

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -36,7 +36,7 @@ class Gnupg < Formula
   # Upstream commit 16 May 2017 "Suppress error for card availability check."
   # See https://dev.gnupg.org/rGa8dd96826f8484c0ae93c954035b95c2a75c80f2
   patch do
-    url "https://files.gnupg.net/file/data/4cbbk5wdkpo72hbwah6g/PHID-FILE-sxw2ecnjqxzopc2wimxp/file"
+    url "https://files.gnupg.net/file/data/tpzhzieuzjdbjd3ortg4/PHID-FILE-volr5hikbsr5vu4ggfr3/file"
     sha256 "3adb7fd095f8bc29fd550bf499f5f198dd20e3d5c97d5bcb79e91d95fd53a781"
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

While installing Gnupg2 without a bottle I got a 404 error for [this upstream patch file](https://files.gnupg.net/file/data/4cbbk5wdkpo72hbwah6g/PHID-FILE-sxw2ecnjqxzopc2wimxp/file), related to [this issue](https://dev.gnupg.org/rGa8dd96826f8484c0ae93c954035b95c2a75c80f2).
This fixes it, pointing the formula to the updated upstream url.